### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,4 +12,4 @@ steps:
             - "test/**"
           target: ".buildkite/run_tests.yml"
     agents:
-      queue: "juliagpu"
+      queue: "cuda"

--- a/.buildkite/run_tests.yml
+++ b/.buildkite/run_tests.yml
@@ -19,8 +19,7 @@ steps:
                 using Pkg
                 Pkg.test("FastIce"; test_args=["--backend=CUDA"], coverage=true)'
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     timeout_in_minutes: 120
     soft_fail:
       - exit_status: 3
@@ -45,8 +44,7 @@ steps:
                 using Pkg
                 Pkg.test("FastIce"; test_args=["--backend=AMDGPU"], coverage=true)'
     agents:
-      queue: "juliagpu"
-      rocm: "*"
+      queue: "rocm"
       rocmgpu: "*"
     timeout_in_minutes: 120
     soft_fail:


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"` or `queue: "rocm"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm` tag. The forerunner launcher step in `pipeline.yml`, which previously targeted the generic `juliagpu` queue, now runs on the `cuda` queue (it only uploads the actual test pipeline, so any agent works).

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)